### PR TITLE
Updated SellingScreen and SellerFulfillingOrderScreen for issues #92 and #98.

### DIFF
--- a/src/main/java/screens/SellerFulfillingOrderScreen.java
+++ b/src/main/java/screens/SellerFulfillingOrderScreen.java
@@ -20,6 +20,7 @@ public class SellerFulfillingOrderScreen extends JFrame{
 
     public SellerFulfillingOrderScreen(SignUpDsGateway signUpGateway, OrderDsGateway orderGateway, String sellerEmail, double price) throws DoesNotExistException {
         JPanel pnl = new JPanel(new GridLayout(3,1));
+        JPanel bottomPanel = new JPanel(new GridLayout(1,3));
 
         int orderNumber = orderGateway.getOrderNumberFromSellerEmail(sellerEmail);
         OrderDsModel orderDsModel = orderGateway.getOrderInfo(orderNumber);
@@ -53,7 +54,6 @@ public class SellerFulfillingOrderScreen extends JFrame{
         });
         JButton orderFulfilledButton = new JButton("ORDER FULFILLED!");
         pnl.add(orderPanel);
-        pnl.add(chatButton);
 
         OrderStatusType orderStatus = orderGateway.getOrderStatus(orderNumber);
         if (orderStatus == OrderStatusType.SELLER_CONFIRMED) {
@@ -93,6 +93,20 @@ public class SellerFulfillingOrderScreen extends JFrame{
                 }
             });
         }
+
+        JButton backButton = new JButton("Back");
+        backButton.addActionListener(actionEvent -> {
+            this.dispose();
+            try {
+                SellerMain.create(sellerEmail, orderDsModel.getResidence());
+            } catch (DoesNotExistException e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        pnl.add(bottomPanel);
+        bottomPanel.add(chatButton);
+        bottomPanel.add(backButton);
 
         this.add(pnl);
         this.setTitle("Fulfilling Order");

--- a/src/main/java/screens/SellingScreen.java
+++ b/src/main/java/screens/SellingScreen.java
@@ -127,6 +127,7 @@ public class SellingScreen extends JFrame {
             JLabel noOrderLabel = new JLabel("There is currently no orders for this residence. ");
             noOrderLabel.setHorizontalAlignment(JLabel.CENTER);
             pnl.add(noOrderLabel);
+            acceptButton.setVisible(false);
         }
 
 


### PR DESCRIPTION
SellingScreen: Hides the Accept Order button if there is no orders for the seller's residence. This addresses issue #98 https://github.com/CSC207-2022F-UofT/course-project-group-134/issues/98

SellerFulfillingOrderScreen: Adds a back button which upon being pressed restarts the selling use case. Currently does nothing, but once multiple orders per seller is implemented, it will send the seller back to the SellingScreen. This addresses issue #92 https://github.com/CSC207-2022F-UofT/course-project-group-134/issues/92